### PR TITLE
Properly save and restore fearedmon property.

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -35,8 +35,8 @@ STATIC_DCL struct monst *FDECL(restmonchn, (int, BOOLEAN_P));
 STATIC_DCL struct fruit *FDECL(loadfruitchn, (int));
 STATIC_DCL void FDECL(freefruitchn, (struct fruit *));
 STATIC_DCL void FDECL(ghostfruit, (struct obj *));
-STATIC_DCL boolean FDECL(restgamestate, (int, unsigned int *, unsigned int *));
-STATIC_DCL void FDECL(restlevelstate, (unsigned int, unsigned int));
+STATIC_DCL boolean FDECL(restgamestate, (int, unsigned int *, unsigned int *, unsigned int *));
+STATIC_DCL void FDECL(restlevelstate, (unsigned int, unsigned int, unsigned int));
 STATIC_DCL int FDECL(restlevelfile, (int, XCHAR_P));
 STATIC_OVL void FDECL(restore_msghistory, (int));
 STATIC_DCL void FDECL(reset_oattached_mids, (BOOLEAN_P));
@@ -542,9 +542,9 @@ register struct obj *otmp;
 
 STATIC_OVL
 boolean
-restgamestate(fd, stuckid, steedid)
+restgamestate(fd, stuckid, steedid, fearedmonid)
 register int fd;
-unsigned int *stuckid, *steedid;
+unsigned int *stuckid, *steedid, *fearedmonid;
 {
     struct flag newgameflags;
 #ifdef SYSFLAGS
@@ -706,6 +706,9 @@ unsigned int *stuckid, *steedid;
         mread(fd, (genericptr_t) stuckid, sizeof *stuckid);
     if (u.usteed)
         mread(fd, (genericptr_t) steedid, sizeof *steedid);
+    if (u.fearedmon) {
+        mread(fd, (genericptr_t) fearedmonid, sizeof *fearedmonid);
+    }
     mread(fd, (genericptr_t) pl_character, sizeof pl_character);
 
     mread(fd, (genericptr_t) pl_fruit, sizeof pl_fruit);
@@ -733,8 +736,8 @@ unsigned int *stuckid, *steedid;
  * don't dereference a wild u.ustuck when saving the game state, for instance)
  */
 STATIC_OVL void
-restlevelstate(stuckid, steedid)
-unsigned int stuckid, steedid;
+restlevelstate(stuckid, steedid, fearedmonid)
+unsigned int stuckid, steedid, fearedmonid;
 {
     register struct monst *mtmp;
 
@@ -754,6 +757,14 @@ unsigned int stuckid, steedid;
             panic("Cannot find the monster usteed.");
         u.usteed = mtmp;
         remove_monster(mtmp->mx, mtmp->my);
+    }
+    if (fearedmonid) {
+        for (mtmp = fmon; mtmp; mtmp = mtmp->nmon)
+            if (mtmp->m_id == fearedmonid)
+                break;
+        if (!mtmp)
+            panic("Cannot find the monster fearedmon.");
+        u.fearedmon = mtmp;
     }
 }
 
@@ -819,7 +830,7 @@ int
 dorecover(fd)
 register int fd;
 {
-    unsigned int stuckid = 0, steedid = 0; /* not a register */
+    unsigned int stuckid = 0, steedid = 0, fearedmonid = 0; /* not a register */
     xchar ltmp;
     int rtmp;
     struct obj *otmp;
@@ -827,7 +838,7 @@ register int fd;
     program_state.restoring = 1;
     get_plname_from_file(fd, plname);
     getlev(fd, 0, (xchar) 0, FALSE);
-    if (!restgamestate(fd, &stuckid, &steedid)) {
+    if (!restgamestate(fd, &stuckid, &steedid, &fearedmonid)) {
         display_nhwindow(WIN_MESSAGE, TRUE);
         savelev(-1, 0, FREE_SAVE); /* discard current level */
         (void) nhclose(fd);
@@ -835,7 +846,7 @@ register int fd;
         program_state.restoring = 0;
         return 0;
     }
-    restlevelstate(stuckid, steedid);
+    restlevelstate(stuckid, steedid, fearedmonid);
     /* check crowned infidels (demonic form) for its wings,
        ensure they stay tucked away under their body armor
        upon reload */
@@ -855,6 +866,7 @@ register int fd;
      */
     u.ustuck = (struct monst *) 0;
     u.usteed = (struct monst *) 0;
+    u.fearedmon = (struct monst *) 0;
 
 #ifdef MICRO
 #ifdef AMII_GRAPHICS
@@ -918,7 +930,7 @@ register int fd;
      */
     reset_restpref();
 
-    restlevelstate(stuckid, steedid);
+    restlevelstate(stuckid, steedid, fearedmonid);
     program_state.something_worth_saving = 1; /* useful data now exists */
 
     if (!wizard && !discover)

--- a/src/save.c
+++ b/src/save.c
@@ -73,7 +73,7 @@ static struct save_procs {
 #endif
 
 /* need to preserve these during save to avoid accessing freed memory */
-static unsigned ustuck_id = 0, usteed_id = 0;
+static unsigned ustuck_id = 0, usteed_id = 0, ufearedmon_id = 0;
 static struct obj *looseball = (struct obj *) 0;  /* track uball during save and... */
 static struct obj *loosechain = (struct obj *) 0; /* track uchain since saving might free it */
 
@@ -236,6 +236,7 @@ dosave0()
     store_plname_in_file(fd);
     ustuck_id = (u.ustuck ? u.ustuck->m_id : 0);
     usteed_id = (u.usteed ? u.usteed->m_id : 0);
+    ufearedmon_id = (u.fearedmon ? u.fearedmon->m_id : 0);
     /* savelev() might save uball and uchain, releasing their memory if
        FREEING, so we need to check their status now; if hero is swallowed,
        uball and uchain will persist beyond saving map floor and inventory
@@ -260,6 +261,7 @@ dosave0()
      */
     u.ustuck = (struct monst *) 0;
     u.usteed = (struct monst *) 0;
+    u.fearedmon = (struct monst *) 0;
 
     for (ltmp = (xchar) 1; ltmp <= maxledgerno(); ltmp++) {
         if (ltmp == ledger_no(&uz_save))
@@ -372,6 +374,10 @@ register int fd, mode;
         bwrite(fd, (genericptr_t) &ustuck_id, sizeof ustuck_id);
     if (usteed_id)
         bwrite(fd, (genericptr_t) &usteed_id, sizeof usteed_id);
+    if (ufearedmon_id) {
+        bwrite(fd, (genericptr_t) &ufearedmon_id, sizeof ufearedmon_id);
+    }
+        
     bwrite(fd, (genericptr_t) pl_character, sizeof pl_character);
     bwrite(fd, (genericptr_t) pl_fruit, sizeof pl_fruit);
     savefruitchn(fd, mode);
@@ -469,6 +475,7 @@ savestateinlock()
 
             ustuck_id = (u.ustuck ? u.ustuck->m_id : 0);
             usteed_id = (u.usteed ? u.usteed->m_id : 0);
+            ufearedmon_id = (u.fearedmon ? u.fearedmon->m_id : 0);
             /* if ball and/or chain aren't on floor or in invent, keep a copy
                of their pointers; not valid when on floor or in invent */
             looseball = BALL_IN_MON ? uball : 0;


### PR DESCRIPTION

The game panics under certain conditions when the player is made afraid when the `talk` parameter to `make_afraid` is true.

One way to reproduce this:
- Player was recently made afraid by a monster
- Player cures fear (may not be strictly required)
- Player saves game
- Player restores game
- Player kills monster
- Player is made afraid by some source that passes in `talk = true`, meaning it needs to inform the player what monster is causing the fear
- Game panics

## Some ttyrecs
- https://hdf-us.s3.amazonaws.com/ttyrec/S/Sylvie/hackem/ttyrec/2024-07-26.04:36:23.ttyrec.gz
- https://www.hardfought.org/userdata/S/Sylvie/hackem/ttyrec/2024-07-27.20:20:05.ttyrec.gz 
  (above link will expire when archived)

## Proposed fix
`u.fearedmon` is not properly saved and restored when saving and restoring the save game file. It's old pointer memory address is loaded when loading the game, which is virtually always invalid.

This fix points `u.fearedmon` to the right monster object on save game restore, in the same manner as is done for steeds and stuck/engulfing monsters. It also needs to actually save the ID of the monster to the save file if `fearedmon` is set, which will break save game compatibility. This may require a version bump?